### PR TITLE
Fix chromedriver 1

### DIFF
--- a/.github/workflows/second-email-flow.yml
+++ b/.github/workflows/second-email-flow.yml
@@ -1,7 +1,7 @@
 name: Email Flow
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "fix-chromedriver-1"]
   workflow_dispatch:
 
 jobs:

--- a/src/allocator/driver.py
+++ b/src/allocator/driver.py
@@ -1,9 +1,7 @@
 import platform
 import os
 import shutil
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 import datetime
-import requests
 
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
@@ -15,8 +13,10 @@ from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.edge.service import Service as EdgeService
 from webdriver_manager.microsoft import EdgeChromiumDriverManager
 from selenium.webdriver.edge.options import Options as EdgeOptions
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from utils.dirs import get_root_dir, get_curr_dir
+
 
 class Driver(object):
     def __init__(self, context):
@@ -57,9 +57,8 @@ class Driver(object):
     def chrome_default(self):
         desired_capabilities = DesiredCapabilities.CHROME
         options = self.set_chrome_browser_options_arguments(self)
-        chrome_driver_version = self.get_chrome_driver_version()
         return webdriver.Chrome(
-            service=ChromeService(ChromeDriverManager(chrome_driver_version).install()),
+            service=ChromeService(ChromeDriverManager().install()),
             chrome_options=options,
             desired_capabilities=desired_capabilities,
         )
@@ -137,9 +136,3 @@ class Driver(object):
             path_to_capture_screenshot
         )  # need to refactor this line
         return path_to_capture_screenshot
-
-    @staticmethod
-    def get_chrome_driver_version():
-        response = requests.get('https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json')
-        data = response.json()
-        return data['chromeDriver']

--- a/src/allocator/driver.py
+++ b/src/allocator/driver.py
@@ -31,8 +31,23 @@ class Driver(object):
     def chrome(self):
         if platform.system() == 'Darwin' and platform.machine() == 'arm64':
             return self.chrome_mac_arm64()
+        elif platform.system() == 'Linux' and platform.machine() == 'x86_64':
+            return self.chrome_linux64()
         else:
             return self.chrome_default()
+
+    def chrome_linux64(self):
+        desired_capabilities = DesiredCapabilities.CHROME
+        options = self.set_chrome_browser_options_arguments(self)
+        root_dir = get_root_dir(get_curr_dir(__file__))
+        web_drivers_dir = f"{root_dir}/test/resources/browserdrivers"
+        chrome_binary_path = f"{web_drivers_dir}/chromedriver_linux64"
+
+        return webdriver.Chrome(
+            chrome_options=options,
+            desired_capabilities=desired_capabilities,
+            executable_path=chrome_binary_path
+        )
 
     def chrome_mac_arm64(self):
         desired_capabilities = DesiredCapabilities.CHROME

--- a/src/allocator/driver.py
+++ b/src/allocator/driver.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 import datetime
+import requests
 
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
@@ -16,7 +17,6 @@ from webdriver_manager.microsoft import EdgeChromiumDriverManager
 from selenium.webdriver.edge.options import Options as EdgeOptions
 
 from utils.dirs import get_root_dir, get_curr_dir
-
 
 class Driver(object):
     def __init__(self, context):
@@ -57,8 +57,9 @@ class Driver(object):
     def chrome_default(self):
         desired_capabilities = DesiredCapabilities.CHROME
         options = self.set_chrome_browser_options_arguments(self)
+        chrome_driver_version = self.get_chrome_driver_version()
         return webdriver.Chrome(
-            service=ChromeService(ChromeDriverManager().install()),
+            service=ChromeService(ChromeDriverManager(chrome_driver_version).install()),
             chrome_options=options,
             desired_capabilities=desired_capabilities,
         )
@@ -136,3 +137,9 @@ class Driver(object):
             path_to_capture_screenshot
         )  # need to refactor this line
         return path_to_capture_screenshot
+
+    @staticmethod
+    def get_chrome_driver_version():
+        response = requests.get('https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json')
+        data = response.json()
+        return data['chromeDriver']

--- a/temp.txt
+++ b/temp.txt
@@ -1,0 +1,34 @@
+    def chrome(self):
+        if platform.system() == 'Darwin' and platform.machine() == 'arm64':
+            return self.chrome_mac_arm64()
+        else:
+            return self.chrome_default()
+
+    def chrome_mac_arm64(self):
+        desired_capabilities = DesiredCapabilities.CHROME
+        options = self.set_chrome_browser_options_arguments(self)
+        root_dir = get_root_dir(get_curr_dir(__file__))
+        web_drivers_dir = f"{root_dir}/test/resources/browserdrivers"
+        chrome_binary_path = f"{web_drivers_dir}/chromedriver_mac_arm64"
+        chrome_app_path = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+
+        if not os.path.exists(chrome_app_path):
+            print("Google Chrome is not installed. Installing now...")
+            os.system("brew install --cask google-chrome")
+            print("Installation finished. If the script fails, please run it again.")
+
+        options.binary_location = chrome_app_path
+        return webdriver.Chrome(
+            chrome_options=options,
+            desired_capabilities=desired_capabilities,
+            executable_path=chrome_binary_path
+        )
+
+    def chrome_default(self):
+        desired_capabilities = DesiredCapabilities.CHROME
+        options = self.set_chrome_browser_options_arguments(self)
+        return webdriver.Chrome(
+            service=ChromeService(ChromeDriverManager().install()),
+            chrome_options=options,
+            desired_capabilities=desired_capabilities,
+        )


### PR DESCRIPTION
Error below fixed with updated driver.py and added chromedriver_linux64 file. Merging.

```zsh
Run source .venv/bin/activate
  source .venv/bin/activate
  mapfile -t BEHAVE_OUTPUT < <(behave \
    --verbose \
    --tags=@simple \
    --format=allure_behave.formatter:AllureFormatter \
    --summary \
    --outfile $TEST_RESULTS_DIR \
    --include simple 2>&1) || BEHAVE_EXIT_CODE=$?
  
  IMPORTANT_LINE=$(echo "${BEHAVE_OUTPUT[*]}" \
    | grep -o '[0-9]* feature\(s\)\? passed.*') \
    || GREP_EXIT_CODE=$?
  
  printf "%s\n" "${BEHAVE_OUTPUT[@]}"
  
  if [ "$GREP_EXIT_CODE" -eq 1 ]; then
    echo "::error::Process ended with exit code ${BEHAVE_EXIT_CODE}"
  else
    GREP_EXIT_CODE=0
    if [[ "$IMPORTANT_LINE" =~ "0 features passed" ]]; then
      echo "::warning::${IMPORTANT_LINE}"
    else
      echo "::notice::${IMPORTANT_LINE}"
    fi
  fi
  
  printf "%s\n" "${BEHAVE_OUTPUT[@]}" > behave-stdout.txt
  
  echo "BDD_STDOUT=behave-stdout.txt" >> $GITHUB_ENV
  echo "BDD_PASS_STATUS=${GREP_EXIT_CODE}" >> $GITHUB_ENV
  shell: /usr/bin/bash -e {0}
  env:
    TEST_RESULTS_DIR: allure-results
    ALLURE_REPORT_DIR: allure-report
    pythonLocation: /opt/hostedtoolcache/Python/3.11.4/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.4/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.4/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.4/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.4/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.4/x64/lib
    PIP_CACHE_DIR: /home/runner/.cache/pip
Loading config defaults from "./behave.ini"
Using defaults:
          color True
  show_snippets True
   show_skipped True
        dry_run False
    show_source True
   show_timings True
 stdout_capture True
 stderr_capture True
    log_capture True
/home/runner/work/_temp/ca170a53-59a0-48b8-b43c-d4270a563bbe.sh: line 16: [: : integer expression expected
 logging_format %(levelname)s:%(name)s:%(message)s
  logging_level 20
  steps_catalog False
        summary True
          junit False
          stage None
       userdata {'env': 'None', 'browser': 'chrome', 'mode': 'headless'}
 default_format pretty
   default_tags 
scenario_outline_annotation_schema {name} -- @{row.id} {examples.name}
more_formatters {}
Using default path "./features"
Trying base directory: /home/runner/work/selenium-test/selenium-test/features
Trying base directory: /home/runner/work/selenium-test/selenium-test
HOOK-ERROR in before_scenario: Exception: No such driver version 115.0.5790.110 for linux64
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/behave/runner.py", line 545, in run_hook
    self.hooks[name](context, *args)
  File "environment.py", line 29, in before_scenario
    context.driver = driver_instance.get_driver()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/src/allocator/driver.py", line 29, in get_driver
    return web_driver()
           ^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/src/allocator/driver.py", line 35, in chrome
    return self.chrome_default()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/src/allocator/driver.py", line 61, in chrome_default
    service=ChromeService(ChromeDriverManager().install()),
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/webdriver_manager/chrome.py", line 39, in install
    driver_path = self._get_driver_binary_path(self.driver)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/webdriver_manager/core/manager.py", line 33, in _get_driver_binary_path
    file = self._download_manager.download_file(driver.get_driver_download_url())
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/webdriver_manager/drivers/chrome.py", line 59, in get_driver_download_url
    modern_version_url = self.get_url_for_version_and_platform(driver_version_to_download, os_type)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/webdriver_manager/drivers/chrome.py", line 94, in get_url_for_version_and_platform
    raise Exception(f"No such driver version {browser_version} for {platform}")
HOOK-ERROR in before_scenario: Exception: No such driver version 115.0.5790.110 for linux64
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/behave/runner.py", line 545, in run_hook
    self.hooks[name](context, *args)
  File "environment.py", line 29, in before_scenario
    context.driver = driver_instance.get_driver()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/src/allocator/driver.py", line 29, in get_driver
    return web_driver()
           ^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/src/allocator/driver.py", line 35, in chrome
    return self.chrome_default()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/src/allocator/driver.py", line 61, in chrome_default
    service=ChromeService(ChromeDriverManager().install()),
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/webdriver_manager/chrome.py", line 39, in install
    driver_path = self._get_driver_binary_path(self.driver)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/webdriver_manager/core/manager.py", line 33, in _get_driver_binary_path
    file = self._download_manager.download_file(driver.get_driver_download_url())
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/webdriver_manager/drivers/chrome.py", line 59, in get_driver_download_url
    modern_version_url = self.get_url_for_version_and_platform(driver_version_to_download, os_type)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/selenium-test/selenium-test/.venv/lib/python3.11/site-packages/webdriver_manager/drivers/chrome.py", line 94, in get_url_for_version_and_platform
    raise Exception(f"No such driver version {browser_version} for {platform}")

Failing scenarios:
  features/simple.feature:4  Visit the home page
  features/simple.feature:9  Visit example dot com

0 features passed, 1 failed, 0 skipped
0 scenarios passed, 2 failed, 0 skipped
0 steps passed, 0 failed, 0 skipped, 0 undefined, 2 untested
Took 0m0.000s
Warning: 0 features passed, 1 failed, 0 skipped 0 scenarios passed, 2 failed, 0 skipped 0 steps passed, 0 failed, 0 skipped, 0 undefined, 2 untested Took 0m0.000s
```